### PR TITLE
flatcar-install: make sure `blkid` returns one device

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -716,10 +716,10 @@ function write_cloudinit() {
     (
     # The ROOT partition should be #9 but make no assumptions here!
     # Also don't mount by label directly in case other devices conflict.
-    local ROOT_DEV=$(blkid -t "LABEL=ROOT" -o device "${DEVICE}"*)
+    local ROOT_DEV=$(blkid -l -t "LABEL=ROOT" -o device "${DEVICE}"*)
 
     mkdir -p "${WORKDIR}/rootfs"
-    case $(blkid -t "LABEL=ROOT" -o value -s TYPE "${ROOT_DEV}") in
+    case $(blkid -l -t "LABEL=ROOT" -o value -s TYPE "${ROOT_DEV}") in
       "btrfs") mount -t btrfs -o subvol=root "${ROOT_DEV}" "${WORKDIR}/rootfs" ;;
       *)       mount "${ROOT_DEV}" "${WORKDIR}/rootfs" ;;
     esac
@@ -745,7 +745,7 @@ function write_ignition() {
     (
     # The OEM partition should be #6 but make no assumptions here!
     # Also don't mount by label directly in case other devices conflict.
-    local OEM_DEV=$(blkid -t "LABEL=OEM" -o device "${DEVICE}"*)
+    local OEM_DEV=$(blkid -l -t "LABEL=OEM" -o device "${DEVICE}"*)
 
     mkdir -p "${WORKDIR}/oemfs"
     mount "${OEM_DEV}" "${WORKDIR}/oemfs" || { btrfstune -f -u "${OEM_DEV}" ; mount "${OEM_DEV}" "${WORKDIR}/oemfs" ; }


### PR DESCRIPTION
In some cases where path disk devices have multiple copies, `blkid` should return only one device for label.

According to https://linux.die.net/man/8/blkid, the `-l` would be perfect for this, as it returns the regular block device first.

Fixes: https://github.com/flatcar/Flatcar/issues/1506